### PR TITLE
Fixing fatal errors with comments

### DIFF
--- a/templates/comment.twig
+++ b/templates/comment.twig
@@ -1,0 +1,35 @@
+{# comment.twig #}
+<div class="single-comment">
+    <div id="comment-{{ comment.id }}">
+        <div class="row">
+            <div class="col-md-2 col-xl-1 avatar">
+                {#			<img src="{{ comment.author_image_src }}" alt="{{ comment.author_image_alt }}" />#}
+                {{ function('get_avatar', comment.id ) }}
+            </div>
+            <div class="col-md-10 col-xl-11">
+                <div class="author">{{ comment.author.name }}</div>
+                <div class="date">{{ comment.date }}</div>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col comment-content">
+                {{ comment.content }}
+            </div>
+        </div>
+        <div class="row">
+            <div class="col reply-link">
+                {{ comment.reply_link }}
+            </div>
+        </div>
+    </div>
+    <div class="respond comment-form">
+
+    </div>
+    {% if comment.children %}
+        {% for reply in comment.children %}
+            {% include 'comment.twig' with {
+                comment: reply,
+            } %}
+        {% endfor %}
+    {% endif %}
+</div>

--- a/templates/single.twig
+++ b/templates/single.twig
@@ -30,7 +30,7 @@
 				{% if post.comment_status == "closed" %}
 					<p> comments for this post are closed </p>
 				{% else %}
-				    <!-- comment form -->
+					<!-- comment form -->
 					{{ function('comment_form') }}
 				{% endif %}
 			</section>

--- a/templates/single.twig
+++ b/templates/single.twig
@@ -31,7 +31,7 @@
 					<p> comments for this post are closed </p>
 				{% else %}
 				    <!-- comment form -->
-				    {% include "comment-form.twig" %}
+					{{ function('comment_form') }}
 				{% endif %}
 			</section>
 		</article>


### PR DESCRIPTION
I noticed there is a fatal error when viewing the Hello World post when setting up the AcuTech theme. I copied `comment.twig` from the daggerhartlab dot com website repo and used the `comment_form` function instead of including a template and that worked to fix the problem.